### PR TITLE
#81 Correção na pipeline de publicação

### DIFF
--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -22,19 +22,15 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install build
+          pip install twine
 
       - name: Build package
         run: python -m build
 
       - name: Publish package on test pypi
         if: github.ref == 'refs/heads/develop'
-        uses: pypa/gh-action-pypi-publish@release/v1
-        with:
-          password: ${{ secrets.TEST_PYPI_API_TOKEN }}
-          repository_url: https://test.pypi.org/legacy/
+        run: python -m twine upload -u __token__ -p ${{ secrets.TEST_PYPI_API_TOKEN }} --repository testpypi dist/*
 
       - name: Publish package on pypi
         if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags')
-        uses: pypa/gh-action-pypi-publish@release/v1
-        with:
-          password: ${{ secrets.PYPI_API_TOKEN }}
+        run: python -m twine upload -u __token__ -p ${{ secrets.PYPI_API_TOKEN }} dist/*

--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -2,6 +2,7 @@ name: Publicar pacote
 
 on:
   push:
+    branches: [ develop ]
     tags:
       - "v*"
 
@@ -25,8 +26,15 @@ jobs:
       - name: Build package
         run: python -m build
 
-      - name: Publish package
-        uses: pypa/gh-action-pypi-publish@27b31702a0e7fc50959f5ad993c78deac1bdfc29
+      - name: Publish package on test pypi
+        if: github.ref == 'refs/heads/develop'
+        uses: pypa/gh-action-pypi-publish@release/v1
         with:
-          user: __token__
+          password: ${{ secrets.TEST_PYPI_API_TOKEN }}
+          repository_url: https://test.pypi.org/legacy/
+
+      - name: Publish package on pypi
+        if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags')
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
           password: ${{ secrets.PYPI_API_TOKEN }}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "msgram"
-version = "1.0.0"
+version = "1.0.1"
 description = "The msgram CLI is a command-line interface to use MeasureSoftGram software"
 readme = "README.md"
 authors = [

--- a/tests/system/test_extract.py
+++ b/tests/system/test_extract.py
@@ -13,14 +13,6 @@ def capture(command):
     return out, err, proc.returncode
 
 
-# def command_extract_should_succeed():
-#     config_dirpath = tempfile.mkdtemp()
-#     breakpoint()
-#     _, err, returncode = capture(
-#         ["msgram", "extract", "-o", "sonarqube", "-cp", config_dirpath, "-dp", "sonar-output-fake"]
-#     )
-
-
 def test_extract_metrics_folder_not_found_exception_handling():
     config_dirpath = tempfile.mkdtemp()
     _, err, returncode = capture(


### PR DESCRIPTION
#  Melhoria e correção na pipeline de publicação

## Descrição
As alterações buscam resolver o problema na publicação automática do pacote, bem como promover um novo trigger para pacotes de teste que seria a publicação no test pypi quando o pacote estiver em develop.

[#81](https://github.com/fga-eps-mds/2022-2-measuresoftgram-doc/issues/81)

## Critérios de aceitação

1. [x] A publicação funcionar corretamente com a action utilizada

## Imagem comprobatória do funcionamento (foi utilizada essa branch como trigger)
![image](https://user-images.githubusercontent.com/74625814/215914391-dea78fa5-ffaa-4258-9ab7-5c935e0eccd3.png)

